### PR TITLE
Fix module registration.

### DIFF
--- a/RasterPropMonitor/Core/IJSIModule.cs
+++ b/RasterPropMonitor/Core/IJSIModule.cs
@@ -43,11 +43,12 @@ namespace JSI
 
         internal static void CreateJSIModules(List<IJSIModule> modules, Vessel v)
         {
+            object[] constructorArgs = new[] { v };
             foreach (Type t in x_registeredTypes)
             {
                 try
                 {
-                    modules.Add((IJSIModule)Activator.CreateInstance(t, v));
+                    modules.Add((IJSIModule)Activator.CreateInstance(t, constructorArgs));
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This was causing an issue where where the recovery button would not work.
For some reason, the `CreateInstance` overload coerced a `Vessel` into a `bool` and tried to find a default constructor. I pass an array of objects instead which selects the right overload and actually loads the module.