### PR TITLE
Allow targeting flags, landed vessels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please always post your [KSP.log file](https://gist.github.com/JonnyOThan/04c207
 ### New Features
 
 - Add support for scrolling through orbit patches on the MFD (thanks @andymac-2)
+- Allow targeting flags and landed vessels (thanks @andymac-2)
 
 ### Bug Fixes
 

--- a/RasterPropMonitor/Core/RPMCEvaluators.cs
+++ b/RasterPropMonitor/Core/RPMCEvaluators.cs
@@ -1714,21 +1714,21 @@ namespace JSI
                 case "TIMETOANWITHTARGETSECS":
                     return (RPMVesselComputer comp) =>
                     {
-                        if (comp.target == null || comp.targetOrbit == null)
+                        if (comp.target == null)
                             return double.NaN;
-                        return vessel.GetOrbit().TimeOfAscendingNode(comp.targetOrbit, Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();
+                        return vessel.GetOrbit().TimeOfAscendingNode(comp.target.GetOrbit(), Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();
                     };
                 case "TIMETODNWITHTARGETSECS":
                     return (RPMVesselComputer comp) =>
                     {
-                        if (comp.target == null || comp.targetOrbit == null)
+                        if (comp.target == null)
                             return double.NaN;
-                        return vessel.GetOrbit().TimeOfDescendingNode(comp.targetOrbit, Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();
+                        return vessel.GetOrbit().TimeOfDescendingNode(comp.target.GetOrbit(), Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();
                     };
                 case "TARGETCLOSESTAPPROACHTIME":
                     return (RPMVesselComputer comp) =>
                     {
-                        if (comp.target == null || comp.targetOrbit == null || orbitSensibility == false)
+                        if (comp.target == null || orbitSensibility == false)
                         {
                             return double.NaN;
                         }
@@ -1742,7 +1742,7 @@ namespace JSI
                 case "TARGETCLOSESTAPPROACHDISTANCE":
                     return (RPMVesselComputer comp) =>
                     {
-                        if (comp.target == null || comp.targetOrbit == null || orbitSensibility == false)
+                        if (comp.target == null || orbitSensibility == false)
                         {
                             return double.NaN;
                         }

--- a/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
+++ b/RasterPropMonitor/Handlers/JSIOrbitDisplay.cs
@@ -186,7 +186,7 @@ namespace JSI
             Vector3 midStraight = (startVertex + endVertex) * 0.5f;
             // Debug.Log($"startTA: {startTA}, endTA: {endTA}, startVertex: {startVertex}, endVertex: {endVertex}, midVertex: {midVertex}, midStraight: {midStraight}");
 
-            if (Math.Abs(startTA - endTA) <  0.01 || (midStraight - midVertex).sqrMagnitude < 9.0)
+            if (Math.Abs(startTA - endTA) <  0.01 || (midStraight - midVertex).sqrMagnitude < 16.0)
             {
                 GL.Vertex3(startVertex.x, startVertex.y, 0.0f);
                 GL.Vertex3(midVertex.x, midVertex.y, 0.0f);
@@ -569,29 +569,31 @@ namespace JSI
             {
                 var orbit = (targetVessel != null) ? targetVessel.GetOrbit() : targetBody.GetOrbit();
 
-                double tClosestApproach, dClosestApproach;
+                double tClosestApproach;
 
                 if (targetVessel != null && targetVessel.LandedOrSplashed)
                 {
-                    orbit = JUtil.ClosestApproachSrfOrbit(selectedPatch, targetVessel, out tClosestApproach, out dClosestApproach);
+                    Vector3d position = JUtil.ClosestApproachSrfOrbit(selectedPatch, targetVessel, out tClosestApproach, out double _);
+                    transformedPosition = screenTransform.MultiplyPoint3x4(position);
+                    DrawIcon(transformedPosition.x, transformedPosition.y, targetVessel.vesselType, iconColorTargetValue);
                 }
                 else
                 {
-                    dClosestApproach = JUtil.GetClosestApproach(selectedPatch, orbit, out tClosestApproach);
+                    JUtil.GetClosestApproach(selectedPatch, orbit, out tClosestApproach);
 
                     DrawNextPe(orbit, selectedPatch.referenceBody, now, iconColorTargetValue, screenTransform);
                     DrawNextAp(orbit, selectedPatch.referenceBody, now, iconColorTargetValue, screenTransform);
-                }
 
-                if (targetBody != null)
-                {
-                    transformedPosition = screenTransform.MultiplyPoint3x4(targetBody.getTruePositionAtUT(now) - selectedPatch.referenceBody.getTruePositionAtUT(now));
-                    DrawIcon(transformedPosition.x, transformedPosition.y, VesselType.Unknown, iconColorTargetValue, MapIcons.OtherIcon.PLANET);
-                }
-                else
-                {
-                    transformedPosition = screenTransform.MultiplyPoint3x4(orbit.SwappedRelativePositionAtUT(now));
-                    DrawIcon(transformedPosition.x, transformedPosition.y, targetVessel.vesselType, iconColorTargetValue);
+                    if (targetBody != null)
+                    {
+                        transformedPosition = screenTransform.MultiplyPoint3x4(targetBody.getTruePositionAtUT(now) - selectedPatch.referenceBody.getTruePositionAtUT(now));
+                        DrawIcon(transformedPosition.x, transformedPosition.y, VesselType.Unknown, iconColorTargetValue, MapIcons.OtherIcon.PLANET);
+                    }
+                    else
+                    {
+                        transformedPosition = screenTransform.MultiplyPoint3x4(orbit.SwappedRelativePositionAtUT(now));
+                        DrawIcon(transformedPosition.x, transformedPosition.y, targetVessel.vesselType, iconColorTargetValue);
+                    }
                 }
 
                 if (selectedPatch.AscendingNodeExists(orbit))
@@ -621,10 +623,13 @@ namespace JSI
                     DrawIcon(transformedPosition.x, transformedPosition.y, VesselType.Unknown, iconColorClosestApproachValue, MapIcons.OtherIcon.SHIPATINTERCEPT);
                 }
 
-                // Unconditionally try to draw the closest approach point on
-                // the target orbit.
-                transformedPosition = screenTransform.MultiplyPoint3x4(orbit.SwappedRelativePositionAtUT(tClosestApproach));
-                DrawIcon(transformedPosition.x, transformedPosition.y, VesselType.Unknown, iconColorClosestApproachValue, MapIcons.OtherIcon.TGTATINTERCEPT);
+                if (!targetVessel.LandedOrSplashed)
+                {
+                    // Unconditionally try to draw the closest approach point on
+                    // the target orbit.
+                    transformedPosition = screenTransform.MultiplyPoint3x4(orbit.SwappedRelativePositionAtUT(tClosestApproach));
+                    DrawIcon(transformedPosition.x, transformedPosition.y, VesselType.Unknown, iconColorClosestApproachValue, MapIcons.OtherIcon.TGTATINTERCEPT);
+                }
             }
             else
             {


### PR DESCRIPTION
Fix targeting flags, landed vessels.

Previously, flags would appear right in the middle of the body, and the calculations were way off. Now the orbit display and variables are correct. I think that for landed vessels, it doesn't make sense to have an AN/DN especially if the vessel is not on the equator. However stock KSP shows an AN/DN in the map view, so I corrected the AN/DN to be what stock KSP shows.

Before:
<img width="1415" height="916" alt="Screenshot 2025-10-06 at 3 17 55 pm" src="https://github.com/user-attachments/assets/e23a0eb0-a236-4d58-855a-2c8d0a025e75" />

After:
<img width="1415" height="916" alt="Screenshot 2025-10-06 at 3 15 35 pm" src="https://github.com/user-attachments/assets/2e505cc2-5e9a-4074-b261-74c16885f60a" />
